### PR TITLE
fixed code order bug in liwcalike

### DIFF
--- a/R/liwcalike.R
+++ b/R/liwcalike.R
@@ -85,18 +85,18 @@ liwcalike.character <- function(x, dictionary = NULL, tolower = TRUE, verbose = 
 
     # WC
     result[["WC"]] <- quanteda::ntoken(toks)
+    
+    # WPS (mean words per sentence)
+    result[["WPS"]] <- WPS
+    
+    # Sixltr
+    result[["Sixltr"]] <-
+      sapply(toks, function(y) sum(stringi::stri_length(y) > 6)) / result[["WC"]] * 100
 
     # apply the dictionary, if supplied
     if (!is.null(dictionary)) toks <- tokens_lookup(toks, dictionary)
 
     # no implementation for: Analytic	Clout	Authentic	Tone
-
-    # WPS (mean words per sentence)
-    result[["WPS"]] <- WPS
-
-    # Sixltr
-    result[["Sixltr"]] <-
-        sapply(toks, function(y) sum(stringi::stri_length(y) > 6)) / result[["WC"]] * 100
 
     # Dic (percentage of words in the dictionary)
     result[["Dic"]] <- if (!is.null(dictionary)) {


### PR DESCRIPTION
The location of `if (!is.null(dictionary)) toks <- tokens_lookup(toks, dictionary)` before `result[["Sixltr"]] <- sapply(toks, function(y) sum(stringi::stri_length(y) > 6)) / result[["WC"]] * 100` means that that the output of result[["Sixltr"]] is incorrect and often has a value of over 100, as it is calculating the number of tokens in the dictionary with more than six letters divided by the word count of each string, rather than all the words in that string regardless of it they are in the dictionary.