### PR TITLE
typo_doi_Rauh

### DIFF
--- a/sources/Rauh/create-data_dictionary_Rauh.R
+++ b/sources/Rauh/create-data_dictionary_Rauh.R
@@ -3,7 +3,7 @@
 library("quanteda")
 library("dplyr")
 
-# load dictionary dataframes (downloaded here: https://doi.org/10.7910/DVN/BKBX)
+# load dictionary dataframes (downloaded here: https://doi.org/10.7910/DVN/BKBXWD)
 load("sources/Rauh/Rauh_SentDictionaryGerman_Negation.Rdata")
 load("sources/Rauh/Rauh_SentDictionaryGerman.Rdata")
 


### PR DESCRIPTION
there is a typo in the DOI to Rauh's replication data